### PR TITLE
TCP client and server with TCRP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# ===== Python =====
+__pycache__/
+
+# ===== macOS =====
+.DS_Store

--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,18 @@
+from tcp_client import TCPClient
+
+def main():
+    server_address = input("サーバーアドレス名 (デフォルト: localhost): ").strip() or 'localhost'
+    port = input("ポート番号 (デフォルト: 9090): ").strip()
+    server_port = int(port) if port else 9090
+
+    try:
+        client = TCPClient(server_address, server_port)
+        client.connect()
+        client.run()
+    except KeyboardInterrupt:
+        print("\nユーザーが中断しました。")
+    except Exception as e:
+        print(f"エラー発生: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/client/tcp_client.py
+++ b/client/tcp_client.py
@@ -4,7 +4,7 @@ import json
 import os
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from tcp_protocol import TCRPProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST, STATE_COMPLIANCE, STATE_COMPLETE
+from tcrp import TCRProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST, STATE_COMPLIANCE, STATE_COMPLETE
 
 class TCPClient:
     def __init__(self, host='localhost', port=9090):
@@ -48,11 +48,11 @@ class TCPClient:
         username = input("ユーザー名: ").strip()
 
         try:
-            TCRPProtocol.send_tcrp_message(
+            TCRProtocol.send_tcrp_message(
                 self.client_socket, room_name, op, STATE_REQUEST, username
             )
 
-            op_c, state_c, room_c, payload_c = TCRPProtocol.receive_tcrp_message(self.client_socket)
+            op_c, state_c, room_c, payload_c = TCRProtocol.receive_tcrp_message(self.client_socket)
             if state_c != STATE_COMPLIANCE:
                 print("準拠応答受信エラー")
                 return
@@ -62,7 +62,7 @@ class TCPClient:
                 print("操作失敗（サーバー応答）")
                 return
 
-            op_f, state_f, room_f, payload_f = TCRPProtocol.receive_tcrp_message(self.client_socket)
+            op_f, state_f, room_f, payload_f = TCRProtocol.receive_tcrp_message(self.client_socket)
             if state_f == STATE_COMPLETE:
                 complete_result = json.loads(payload_f)
                 token = complete_result.get("token")

--- a/client/tcp_client.py
+++ b/client/tcp_client.py
@@ -1,0 +1,75 @@
+import socket
+import sys
+import json
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from tcp_protocol import TCRPProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST, STATE_COMPLIANCE, STATE_COMPLETE
+
+class TCPClient:
+    def __init__(self, host='localhost', port=9090):
+        self.host = host
+        self.port = port
+        self.client_socket = None
+
+    def connect(self):
+        try:
+            self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.client_socket.connect((self.host, self.port))
+            print(f"接続成功: {self.host}:{self.port}")
+        except Exception as e:
+            print(f"サーバーに接続できません: {e}")
+            sys.exit(1)
+
+    def run(self):
+        try:
+            while True:
+                print("\n--- メニュー ---")
+                print("1. ルーム作成")
+                print("2. ルーム参加")
+                print("3. 終了")
+                choice = input("選択 (1-3): ").strip()
+
+                if choice == '3':
+                    print("終了します。")
+                    break
+                elif choice in ('1', '2'):
+                    self.handle_create_or_join(choice)
+                else:
+                    print("無効な選択肢です")
+        finally:
+            self.client_socket.close()
+            print("クライアント終了")
+            sys.exit(0)
+
+    def handle_create_or_join(self, choice):
+        op = OP_CREATE_ROOM if choice == '1' else OP_JOIN_ROOM
+        room_name = input("ルーム名: ").strip()
+        username = input("ユーザー名: ").strip()
+
+        try:
+            TCRPProtocol.send_tcrp_message(
+                self.client_socket, room_name, op, STATE_REQUEST, username
+            )
+
+            op_c, state_c, room_c, payload_c = TCRPProtocol.receive_tcrp_message(self.client_socket)
+            if state_c != STATE_COMPLIANCE:
+                print("準拠応答受信エラー")
+                return
+
+            compliance_result = json.loads(payload_c)
+            if not compliance_result.get("success", False):
+                print("操作失敗（サーバー応答）")
+                return
+
+            op_f, state_f, room_f, payload_f = TCRPProtocol.receive_tcrp_message(self.client_socket)
+            if state_f == STATE_COMPLETE:
+                complete_result = json.loads(payload_f)
+                token = complete_result.get("token")
+                print(f"トークン受信: {token}")
+                sys.exit(0)
+            else:
+                print("完了応答が受信できませんでした")
+
+        except Exception as e:
+            print(f"処理エラー: {e}")

--- a/server/server.py
+++ b/server/server.py
@@ -1,0 +1,31 @@
+import threading
+from tcp_server import TCPServer
+
+def main():
+    host = input("ホスト名 (デフォルト: localhost): ").strip() or "localhost"
+
+    port_str = input("ポート番号 (デフォルト: 9090): ").strip()
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError:
+            print("ポート番号が不正です。数値で入力してください。")
+            return
+    else:
+        port = 9090
+
+    server = TCPServer(host, port)
+
+    thread = threading.Thread(target=server.start, daemon=False)
+    thread.start()
+
+    try:
+        thread.join()
+    except KeyboardInterrupt:
+        print("\nCtrl+Cで停止")
+        server.stop()
+        thread.join()
+        print("サーバー停止完了")
+
+if __name__ == "__main__":
+    main()

--- a/server/tcp_server.py
+++ b/server/tcp_server.py
@@ -1,0 +1,111 @@
+import socket
+import threading
+import sys
+import os
+import secrets
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from tcp_protocol import TCRPProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST
+
+class TCPServer:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.socket = None
+        self.running = False
+        self.rooms = {}
+        self.tokens = {}
+        self.room_tokens = {}
+        self.user_tokens = {}
+
+    def start(self):
+        try:
+            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.socket.bind((self.host, self.port))
+            self.socket.listen()
+            self.running = True
+            print(f"TCPサーバー開始: {self.host}:{self.port}")
+
+            while self.running:
+                try:
+                    client_socket, address = self.socket.accept()
+                    print(f"[TCP] 接続: {address}")
+                    threading.Thread(target=self._handle_client, args=(client_socket, address), daemon=True).start()
+                except OSError:
+                    break
+                except Exception as e:
+                    print(f"接続処理エラー: {e}")
+        except Exception as e:
+            print(f"サーバー起動エラー: {e}")
+
+    def _handle_client(self, client_socket, address):
+        try:
+            op, state, room_name, payload = TCRPProtocol.receive_tcrp_message(client_socket)
+
+            if state != STATE_REQUEST:
+                print(f"無効な状態コード: {state}")
+                return
+
+            if op == OP_CREATE_ROOM:
+                success, token = self.create_room(room_name, payload)
+                print(f"{'作成成功' if success else '既に存在'}: ルーム '{room_name}'")
+            elif op == OP_JOIN_ROOM:
+                success, token = self.join_room(room_name, payload)
+                print(f"{'参加成功' if success else '参加失敗'}: ルーム '{room_name}' に {payload} 入室")
+            else:
+                print(f"その操作コードは使えません（コード: {op}）")
+                return
+
+            compliance = TCRPProtocol.build_response_compliance(room_name, op, int(success))
+            complete = TCRPProtocol.build_response_complete(room_name, op, token if success else "")
+            client_socket.sendall(compliance + complete)
+
+        except Exception as e:
+            print(f"クライアント処理エラー: {e}")
+        finally:
+            client_socket.close()
+            print(f"[TCP] 切断: {address}")
+
+    def stop(self):
+        self.running = False
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+            print("ソケット閉じた")
+
+    def generate_token(self):
+        return secrets.token_hex(16)
+
+    def room_exists(self, room_name):
+        return room_name in self.rooms
+
+    def create_room(self, room_name, username):
+        if self.room_exists(room_name):
+            return False, None
+
+        token = self.generate_token()
+        self.rooms[room_name] = {
+            'host': username,
+            'members': [username],
+            'tokens': [token]
+        }
+        self.tokens[token] = (room_name, username, True, None)
+        self.room_tokens[room_name] = [token]
+        self.user_tokens[(room_name, username)] = token
+
+        return True, token
+
+    def join_room(self, room_name, username):
+        if not self.room_exists(room_name):
+            return False, None
+
+        if (room_name, username) in self.user_tokens:
+            return True, self.user_tokens[(room_name, username)]
+
+        token = self.room_tokens[room_name][0]
+        self.rooms[room_name]['members'].append(username)
+        self.tokens[token] = (room_name, username, False, None)
+        self.user_tokens[(room_name, username)] = token
+
+        return True, token

--- a/server/tcp_server.py
+++ b/server/tcp_server.py
@@ -5,7 +5,7 @@ import os
 import secrets
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from tcp_protocol import TCRPProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST
+from tcrp import TCRProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST
 
 class TCPServer:
     def __init__(self, host, port):
@@ -41,7 +41,7 @@ class TCPServer:
 
     def _handle_client(self, client_socket, address):
         try:
-            op, state, room_name, payload = TCRPProtocol.receive_tcrp_message(client_socket)
+            op, state, room_name, payload = TCRProtocol.receive_tcrp_message(client_socket)
 
             if state != STATE_REQUEST:
                 print(f"無効な状態コード: {state}")
@@ -57,8 +57,8 @@ class TCPServer:
                 print(f"その操作コードは使えません（コード: {op}）")
                 return
 
-            compliance = TCRPProtocol.build_response_compliance(room_name, op, int(success))
-            complete = TCRPProtocol.build_response_complete(room_name, op, token if success else "")
+            compliance = TCRProtocol.build_response_compliance(room_name, op, int(success))
+            complete = TCRProtocol.build_response_complete(room_name, op, token if success else "")
             client_socket.sendall(compliance + complete)
 
         except Exception as e:

--- a/tcp_protocol.py
+++ b/tcp_protocol.py
@@ -1,0 +1,71 @@
+import struct
+import json
+import socket
+
+OP_CREATE_ROOM = 1
+OP_JOIN_ROOM = 2
+
+STATE_REQUEST = 0
+STATE_COMPLIANCE = 1
+STATE_COMPLETE = 2
+
+class TCRPProtocol:
+    HEADER_SIZE = 32
+
+    @staticmethod
+    def encode_tcrp_header(room_name_size, operation, state, payload_size):
+        payload_size_bytes = payload_size.to_bytes(28, byteorder='big')
+        return struct.pack('!BBB', room_name_size, operation, state) + b'\x00' + payload_size_bytes
+
+    @staticmethod
+    def decode_tcrp_header(header):
+        if len(header) != TCRPProtocol.HEADER_SIZE:
+            raise ValueError("ヘッダーサイズが不正です")
+        room_name_size, op, state = struct.unpack('!BBB', header[:3])
+        payload_size = int.from_bytes(header[4:], byteorder='big')
+        return room_name_size, op, state, payload_size
+
+    @staticmethod
+    def send_tcrp_message(sock, room_name, operation, state, payload_obj):
+        room_name_bytes = room_name.encode('utf-8')
+        payload_bytes = json.dumps(payload_obj).encode('utf-8')
+        header = TCRPProtocol.encode_tcrp_header(len(room_name_bytes), operation, state, len(payload_bytes))
+        sock.sendall(header + room_name_bytes + payload_bytes)
+
+    @staticmethod
+    def receive_tcrp_message(sock):
+        header = TCRPProtocol._recv_exactly(sock, TCRPProtocol.HEADER_SIZE)
+        if not header:
+            raise ConnectionError("ヘッダー受信中に切断されました")
+        room_name_size, op, state, payload_size = TCRPProtocol.decode_tcrp_header(header)
+
+        room_name_bytes = TCRPProtocol._recv_exactly(sock, room_name_size)
+        payload_bytes = TCRPProtocol._recv_exactly(sock, payload_size)
+
+        room_name = room_name_bytes.decode('utf-8')
+        payload_str = payload_bytes.decode('utf-8')
+        return op, state, room_name, payload_str
+
+    @staticmethod
+    def build_response_compliance(room_name, operation, success):
+        payload = json.dumps({"success": success}).encode('utf-8')
+        room_name_bytes = room_name.encode('utf-8')
+        header = TCRPProtocol.encode_tcrp_header(len(room_name_bytes), operation, STATE_COMPLIANCE, len(payload))
+        return header + room_name_bytes + payload
+
+    @staticmethod
+    def build_response_complete(room_name, operation, token):
+        payload = json.dumps({"token": token}).encode('utf-8')
+        room_name_bytes = room_name.encode('utf-8')
+        header = TCRPProtocol.encode_tcrp_header(len(room_name_bytes), operation, STATE_COMPLETE, len(payload))
+        return header + room_name_bytes + payload
+
+    @staticmethod
+    def _recv_exactly(sock, size):
+        buf = b''
+        while len(buf) < size:
+            part = sock.recv(size - len(buf))
+            if not part:
+                raise ConnectionError("切断されました（受信途中）")
+            buf += part
+        return buf


### PR DESCRIPTION
# TCRPを用いたTCPクライアントとサーバーの実装

# ディレクトリ構成

 - tcrp.py
TCP接続の元，データを送受信する際に使うカスタムプロトコルを記述しているファイル

clientフォルダ
 - client.py
 - tcp_client.py

serverフォルダ
 - server.py
 - tcp_server.py

# 実装機能
 - TCRPを用いたクライアントとサーバーの通信
 - ルーム作成・参加リクエストの処理

# これから実装していく機能
- 作成・参加リクエストの処理が完了したユーザーをチャットルームへ入室させる
- UDPを用いたチャットルーム内でのメッセージの送受信

# 実行方法

## サーバー起動
### Terminal 1
python server.py

## クライアント起動
### Terminal 2
python client.py
### Terminal 3
python client.py