### PR TITLE
feat:👨‍💻#3 Implement UDP chat system

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -1,23 +1,36 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
 from tcp_client import TCP_Create_Join_Client
 from udp_client import UDP_Chat_Client
 
+def prompt_valid_input(prompt_text):
+    while True:
+        value = input(prompt_text).strip()
+        if not value or value.isspace():
+            print("空文字や空白のみは許可されていません。もう一度入力してください。")
+            continue
+        return value
+
 class Client:
-    def __init__(self, host, tcp_port, udp_port):
-        self.host = host
-        self.tcp_client = TCP_Create_Join_Client(host, tcp_port)
-        self.udp_client = UDP_Chat_Client(host, udp_port)
+    def __init__(self, server_ip, tcp_port, udp_port):
+        self.server_ip = server_ip
+        self.tcp_port = tcp_port
+        self.udp_port = udp_port
+        self.tcp_client = TCP_Create_Join_Client(server_ip, tcp_port)
 
     def run(self):
         try:
             while True:
-                print("\n=== クライアント ===")
-                print(f"\n--- TCP接続フェーズ ---")
+                print("\n=== クライアント操作メニュー ===")
                 print("1. ルーム作成")
                 print("2. ルーム参加")
                 print("3. 終了")
-                
-                choice = input("選択してください (1-3): ").strip()
-                
+
+                choice = input("選択してください (1-3): ").strip().translate(str.maketrans("１２３", "123"))
+
                 if choice == '3':
                     print("終了します。")
                     break
@@ -25,84 +38,71 @@ class Client:
                     if self._handle_room_operation(choice):
                         break
                 else:
-                    print("無効な選択肢です")
+                    print("「1」、「2」、または「3」を選んでください")
         except KeyboardInterrupt:
-            print("\nユーザーが中断しました。")
+            print("\n終了します...")
         finally:
             print("クライアント終了")
 
     def _handle_room_operation(self, choice):
-        room_name = input("ルーム名を入力してください: ").strip()
-        username = input("ユーザー名を入力してください: ").strip()
-        
-        if not (room_name and username):
-            print("ルーム名とユーザー名を入力してください")
-            return False
+        room_name = prompt_valid_input("ルーム名を入力してください: ")
+        username = prompt_valid_input("ユーザー名を入力してください: ")
 
+        print(f"\n--- TCP接続フェーズ ---")
         if not self.tcp_client.connect():
+            print("[エラー] TCP接続失敗")
             return False
 
-        try:
-            success = False
-            if choice == '1':
-                print(f"ルーム '{room_name}' を作成中...")
-                success = self.tcp_client.create_room(room_name, username)
-            elif choice == '2':
-                print(f"ルーム '{room_name}' に参加中...")
-                success = self.tcp_client.join_room(room_name, username)
+        success = False
+        if choice == '1':
+            success = self.tcp_client.create_room(room_name, username)
+        elif choice == '2':
+            success = self.tcp_client.join_room(room_name, username)
 
-            if success:
-                token = self.tcp_client.get_token()
-                print(f"TCP認証成功。トークン取得完了")
-                
-                self.tcp_client.disconnect()
-                print("TCPソケットを閉じました")
-                
-                print(f"\n--- UDP接続フェーズ ---")
-                join_success = False
-                if choice == '1':
-                    join_success = self.udp_client.create_and_enter_room(room_name, username, token)
-                elif choice == '2':
-                    join_success = self.udp_client.join_existing_room(room_name, username, token)
-                
-                if join_success:
-                    print(f"\nすべての処理が完了しました")
-                    print(f"   ルーム: {room_name}")
-                    print(f"   ユーザー: {username}")
-                    if choice == '1':
-                        print(f"   状態: ルーム作成者として入室完了")
-                    else:
-                        print(f"   状態: ルーム参加完了")
-                    return True
-                else:
-                    if choice == '1':
-                        print("ルーム作成者入室に失敗しました")
-                    else:
-                        print("ルーム参加に失敗しました")
-                    return False
-            else:
-                print("ルーム操作に失敗しました")
-                return False
-                
-        finally:
-            self.tcp_client.disconnect()
+        if not success:
+            print("[エラー] トークン取得失敗")
+            return False
+
+        token = self.tcp_client.get_token()
+        print(f"トークン取得成功")
+        self.tcp_client.disconnect()
+        print("TCP接続を切断しました")
+
+        print(f"\n--- UDP接続フェーズ ---")
+        print(f"ルーム: {room_name}")
+        print(f"ユーザー: {username}")
+        print(f"状態: {'ルーム作成者として入室' if choice == '1' else 'ルームに参加'}")
+
+        udp_client = UDP_Chat_Client(
+            username=username,
+            server_ip=self.server_ip,
+            server_port=self.udp_port,
+            room_name=room_name,
+            token=token
+        )
+        udp_client.start()
+
+        return True
 
 def main():
-    server_address = input("サーバーアドレス名 (デフォルト: localhost): ").strip() or 'localhost'
-    
-    tcp_port = input("TCPポート番号 (デフォルト: 9090): ").strip()
-    tcp_port = int(tcp_port) if tcp_port else 9090
-    
-    udp_port = input("UDPポート番号 (デフォルト: 9091): ").strip()
-    udp_port = int(udp_port) if udp_port else 9091
-
     try:
-        client = Client(server_address, tcp_port, udp_port)
+        server_ip = input("サーバーアドレス (デフォルト: 127.0.0.1): ").strip() or "127.0.0.1"
+
+        tcp_port_input = input("TCPポート番号 (デフォルト: 9090): ").strip()
+        tcp_port = int(tcp_port_input) if tcp_port_input else 9090
+
+        udp_port_input = input("UDPポート番号 (デフォルト: 9091): ").strip()
+        udp_port = int(udp_port_input) if udp_port_input else 9091
+
+        client = Client(server_ip, tcp_port, udp_port)
         client.run()
+
+    except ValueError:
+        print("[エラー] ポート番号は数値で入力してください")
     except KeyboardInterrupt:
-        print("\nユーザーが中断しました")
+        print("\n終了します...")
     except Exception as e:
-        print(f"エラー発生: {e}")
+        print(f"[エラー] 予期しないエラーが発生しました: {e}")
 
 if __name__ == "__main__":
     main()

--- a/client/tcp_client.py
+++ b/client/tcp_client.py
@@ -1,6 +1,6 @@
 import json
-import socket
 import os
+import socket
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -17,7 +17,7 @@ class TCP_Create_Join_Client:
         try:
             self.client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.client_socket.connect((self.host, self.port))
-            print(f"接続成功: {self.host}:{self.port}")
+            print(f"TCP接続に成功しました")
             return True
         except Exception as e:
             print(f"サーバーに接続できません: {e}")
@@ -56,7 +56,6 @@ class TCP_Create_Join_Client:
             if state_f == STATE_COMPLETE:
                 complete_result = json.loads(payload_f)
                 self.token = complete_result.get("token")
-                print(f"トークン受信: {self.token}")
                 return True
             else:
                 print("完了応答が受信できませんでした")

--- a/client/udp_client.py
+++ b/client/udp_client.py
@@ -1,78 +1,72 @@
+import os
 import socket
+import sys
+import threading
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from protocol.ucrp import build_udp_payload, parse_udp_message
+
+MAX_MESSAGE_SIZE = 4096
 
 class UDP_Chat_Client:
-    def __init__(self, host='localhost', port=9091):
-        self.host = host
-        self.port = port
+    def __init__(self, username, server_ip, server_port, room_name, token):
+        self.username = username
+        self.server_ip = server_ip
+        self.server_port = server_port
+        self.room_name = room_name
+        self.token = token
+        self.running = True
 
-    def join_room_only(self, room_name, username, token, is_creator=False):
-        if is_creator:
-            print(f"作成したルーム '{room_name}' への入室を試行中...")
-        else:
-            print(f"ルーム '{room_name}' への参加を試行中...")
-        
-        udp_sock = None
-        try:
-            udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            server_addr = (self.host, self.port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(("0.0.0.0", 0))
 
-            join_packet = f"{room_name}|{token}|{username}|__JOIN__"
-            print(f"接続パケット送信: {join_packet}")
-            udp_sock.sendto(join_packet.encode('utf-8'), server_addr)
-            
-            if is_creator:
-                print(f"作成者として入室リクエストを送信しました...")
-            else:
-                print(f"参加リクエストを送信しました...")
+    def register(self):
+        payload = build_udp_payload(self.room_name, self.token, "__REGISTER__")
+        self.sock.sendto(payload, (self.server_ip, self.server_port))
+        ip, port = self.sock.getsockname()
+        print()
+        print(f"[登録完了] 自分のアドレス: {ip}:{port}")
+        print()
 
+    def receive_messages(self):
+        while self.running:
             try:
-                udp_sock.settimeout(3.0)
-                print(f"サーバー応答待機中... (タイムアウト: 3秒)")
-                
-                data, server_response_addr = udp_sock.recvfrom(4096)
-                response = data.decode('utf-8')
-                print(f"サーバー応答受信: '{response}' from {server_response_addr}")
-                
-                if "参加が完了しました" in response:
-                    if is_creator:
-                        print(f"ルーム作成者として入室成功: {response}")
-                        print(f"{username} さん、ルーム '{room_name}' の作成と入室が完了しました")
-                    else:
-                        print(f"ルーム参加成功: {response}")
-                        print(f"{username} さん、ルーム '{room_name}' への参加が完了しました")
-                    return True
-                else:
-                    if is_creator:
-                        print(f"ルーム作成者入室失敗: {response}")
-                    else:
-                        print(f"ルーム参加失敗: {response}")
-                        if "存在しません" in response or "見つかりません" in response:
-                            print(f"ルーム '{room_name}' が存在しません。先にルームを作成してください")
-                    return False
-                    
-            except socket.timeout:
-                print("サーバーからの応答がタイムアウトしました（3秒）")
-                if is_creator:
-                    print("ルーム作成者の入室確認ができませんでした")
-                else:
-                    print("ルーム参加の確認ができませんでした")
-                return False
-            except Exception as recv_error:
-                print(f"応答受信エラー: {recv_error}")
-                return False
+                data, _ = self.sock.recvfrom(MAX_MESSAGE_SIZE)
+                if not data:
+                    continue
+                sender, message = parse_udp_message(data)
+                if sender != self.username:
+                    print(f"{sender}: {message}")
+                    print("> ", end="", flush=True)
+            except OSError as e:
+                if not self.running:
+                    break
+                print(f"[受信エラー] {e}")
+                break
 
-        except Exception as e:
-            print(f"UDP処理エラー: {e}")
-            import traceback
-            traceback.print_exc()
-            return False
+    def send_loop(self):
+        try:
+            while self.running:
+                print("> ", end="", flush=True)
+                msg = sys.stdin.readline().strip()
+                if not msg:
+                    continue
+                if msg.lower() in ["exit", "quit", "q"]:
+                    print("チャットを終了します")
+                    break
+                payload = build_udp_payload(self.room_name, self.token, msg)
+                if len(payload) > MAX_MESSAGE_SIZE:
+                    print("エラー: メッセージが4096バイトを超えています")
+                    continue
+                self.sock.sendto(payload, (self.server_ip, self.server_port))
+        except KeyboardInterrupt:
+            print("\nチャットを終了します")
         finally:
-            if udp_sock:
-                udp_sock.close()
-                print("UDPソケットを閉じました")
+            self.running = False
+            self.sock.close()
 
-    def create_and_enter_room(self, room_name, username, token):
-        return self.join_room_only(room_name, username, token, is_creator=True)
-
-    def join_existing_room(self, room_name, username, token):
-        return self.join_room_only(room_name, username, token, is_creator=False)
+    def start(self):
+        self.register()
+        threading.Thread(target=self.receive_messages, daemon=True).start()
+        print("=== チャット開始 === (Ctrl+C または exit/q で終了)")
+        self.send_loop()

--- a/protocol/ucrp.py
+++ b/protocol/ucrp.py
@@ -1,0 +1,62 @@
+def parse_custom_payload(data: bytes) -> tuple[str, str, str, str]:
+    if isinstance(data, bytes):
+        data = data.decode('utf-8')
+    parts = data.split('|')
+    if len(parts) != 4:
+        raise ValueError("Invalid custom protocol format")
+    return tuple(parts)
+
+def build_udp_payload(room_name: str, token: str, message: str) -> bytes:
+    room_bytes = room_name.encode('utf-8')
+    token_bytes = token.encode('utf-8')
+    message_bytes = message.encode('utf-8')
+    return bytes([len(room_bytes), len(token_bytes)]) + room_bytes + token_bytes + message_bytes
+
+def parse_udp_payload(data: bytes) -> tuple[str, str, str]:
+    room_len = data[0]
+    token_len = data[1]
+    room_start = 2
+    token_start = room_start + room_len
+    msg_start = token_start + token_len
+    
+    room_name = data[room_start:token_start].decode('utf-8')
+    token = data[token_start:msg_start].decode('utf-8')
+    message = data[msg_start:].decode('utf-8')
+    return room_name, token, message
+
+def build_udp_message(sender: str, message: str) -> bytes:
+    sender_bytes = sender.encode('utf-8')
+    message_bytes = message.encode('utf-8')
+    return bytes([len(sender_bytes)]) + sender_bytes + message_bytes
+
+def parse_udp_message(data: bytes) -> tuple[str, str]:
+    if not data:
+        return "", ""
+    username_len = data[0]
+    sender = data[1:1 + username_len].decode("utf-8")
+    message = data[1 + username_len:].decode("utf-8")
+    return sender, message
+
+def parse_packet_auto(data: bytes) -> dict:
+    try:
+        decoded = data.decode('utf-8')
+        if '|' in decoded:
+            parts = decoded.split('|')
+            if len(parts) == 4:
+                return {'format': 'string_custom', 'room_name': parts[0], 'token': parts[1], 'username': parts[2], 'operation': parts[3]}
+            elif len(parts) == 3:
+                return {'format': 'string_standard', 'room_name': parts[0], 'token': parts[1], 'message': parts[2]}
+            elif len(parts) == 2:
+                return {'format': 'string_message', 'sender': parts[0], 'message': parts[1]}
+    except:
+        pass
+    
+    try:
+        room_name, token, message = parse_udp_payload(data)
+        return {'format': 'binary_payload', 'room_name': room_name, 'token': token, 'message': message}
+    except:
+        try:
+            sender, message = parse_udp_message(data)
+            return {'format': 'binary_message', 'sender': sender, 'message': message}
+        except:
+            return {'format': 'error'}

--- a/server/room_manager.json
+++ b/server/room_manager.json
@@ -1,0 +1,33 @@
+{
+  "rooms": {
+    "room1": {
+      "host_token": "token_952eb5c64def959cf531ab68f304a248",
+      "members": [
+        "token_952eb5c64def959cf531ab68f304a248",
+        "token_6c7b0f3aa46af569066278600fda8919"
+      ],
+      "created_at": 1754314861.274079
+    }
+  },
+  "tokens": {
+    "token_952eb5c64def959cf531ab68f304a248": {
+      "username": "\"hiroki\"",
+      "room_name": "room1",
+      "is_host": true,
+      "address": [
+        "127.0.0.1",
+        54995
+      ]
+    },
+    "token_6c7b0f3aa46af569066278600fda8919": {
+      "username": "\"kanaru\"",
+      "room_name": "room1",
+      "is_host": false,
+      "address": [
+        "127.0.0.1",
+        52223
+      ]
+    }
+  },
+  "saved_at": "2025-08-04T22:41:16.188831"
+}

--- a/server/room_manager.py
+++ b/server/room_manager.py
@@ -127,3 +127,32 @@ class RoomManager:
         except Exception as e:
             print(f"読み込みエラー: {e}")
             return False
+        
+    def delete_room_if_host_left(self, room_name, token):
+        tokens = self.tokens
+        rooms = self.rooms
+        token_info = tokens.get(token)
+
+        if not token_info:
+            print(f"未知のトークン: {token}")
+            return None
+        room_name = token_info["room_name"]
+
+        if rooms.get(room_name, {}).get("host_token") == token:
+            print(f"ホスト {token_info['username']} のため、ルーム{room_name}を削除します")
+            for member_token in rooms[room_name]["members"]:
+                if member_token in tokens:
+                    del tokens[member_token]
+            del rooms[room_name]
+            self.save_to_json()
+            print(f"ルーム {room_name} と全トークンを削除しました")
+            return None
+        else:
+            print(f"{token_info['username']} がルーム{room_name}から退出します")
+            if token in rooms[room_name]["members"]:
+                rooms[room_name]["members"].remove(token)
+            if token in tokens:
+                del tokens[token]
+            self.save_to_json()
+            print(f"{token_info['username']} のトークンとメンバー情報を削除しました")
+            return None

--- a/server/server.py
+++ b/server/server.py
@@ -34,7 +34,7 @@ def main():
     udp_server = UDP_Chat_Server(host, udp_port, room_manager)
 
     tcp_thread = threading.Thread(target=tcp_server.start, daemon=False)
-    udp_thread = threading.Thread(target=udp_server.bind, daemon=False)
+    udp_thread = threading.Thread(target=udp_server.start, daemon=False)
     
     tcp_thread.start()
     udp_thread.start()

--- a/server/tcp_server.py
+++ b/server/tcp_server.py
@@ -1,7 +1,7 @@
-import threading
 import os
 import socket
 import sys
+import threading
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from protocol.tcrp import TCRProtocol, OP_CREATE_ROOM, OP_JOIN_ROOM, STATE_REQUEST
@@ -23,7 +23,7 @@ class TCP_Create_Join_Server:
             self.socket.bind((self.host, self.tcp_port))
             self.socket.listen()
             self.running = True
-            print(f"TCPサーバー開始: {self.host}:{self.tcp_port}")
+            print(f"[起動] TCPサーバーを {self.host}:{self.tcp_port} にバインドしました")
 
             while self.running:
                 try:

--- a/server/udp_server.py
+++ b/server/udp_server.py
@@ -1,61 +1,103 @@
+import os
 import socket
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from protocol.ucrp import build_udp_message, parse_udp_payload
+
+MAX_MESSAGE_SIZE = 4096
 
 class UDP_Chat_Server:
-    def __init__(self, host, udp_port, room_manager):
+    def __init__(self, host: str, udp_port: int, room_manager):
         self.host = host
         self.udp_port = udp_port
         self.room_manager = room_manager
         self.udp_sock = None
         self.running = False
-    
+
     def bind(self):
+        self.udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.udp_sock.bind((self.host, self.udp_port))
+        self.running = True
+        print(f"[起動] UDPサーバーを {self.host}:{self.udp_port} にバインドしました\n")
+
+    def start(self):
+        self.bind()
+        print("UDPチャットサーバーが起動しました。メッセージを待っています...\n")
+
+        while self.running:
+            try:
+                data, address = self.udp_sock.recvfrom(MAX_MESSAGE_SIZE)
+                if not data:
+                    continue
+                print(f"[受信] UDPパケット: {address} サイズ={len(data)}")
+                self.handle_packet(data, address)
+            except Exception as e:
+                if self.running:
+                    print(f"[受信エラー] {e}")
+
+    def handle_packet(self, data: bytes, address: tuple):
         try:
-            self.udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            self.udp_sock.bind((self.host, self.udp_port))
-            self.running = True
-            print(f"UDPサーバー開始: {self.host}:{self.udp_port}")
-            
-            while self.running:
-                try:
-                    data, client_addr = self.udp_sock.recvfrom(4096)
-                    message = data.decode('utf-8')
-                    self._handle_udp_message(message, client_addr)
-                except Exception as e:
-                    if self.running:
-                        print(f"UDP処理エラー: {e}")
-                        
+            room_name, token, message = parse_udp_payload(data)
+            print(f"[受信処理] ルーム: {room_name}, トークン: {token[:8]}..., メッセージ: {message}")
+            self.process_message(room_name, token, message, address)
         except Exception as e:
-            print(f"UDPサーバー起動エラー: {e}")
-    
-    def _handle_udp_message(self, message, client_addr):
-        try:
-            parts = message.split('|', 3)
-            if len(parts) != 4:
-                return
-                
-            room_name, token, username, content = parts
-            
-            is_valid, reason = self.room_manager.validate_token_and_address(
-                token, room_name
-            )
-            
-            if not is_valid:
-                print(f"無効なUDPメッセージ: {reason}")
-                return
-            
-            if content == "__JOIN__":
-                print(f"[UDP] 接続: {username} がルーム '{room_name}' に参加")
-                
-                confirmation = f"ルーム '{room_name}' への参加が完了しました。"
-                self.udp_sock.sendto(confirmation.encode('utf-8'), client_addr)
-                print(f"参加確認メッセージ送信: {client_addr}")
-                
-        except Exception as e:
-            print(f"UDPメッセージ処理エラー: {e}")
-    
+            print(f"[処理エラー] {e}")
+
+    def process_message(self, room_name: str, token: str, message: str, address: tuple):
+        rooms = self.room_manager.rooms
+        tokens = self.room_manager.tokens
+
+        if message == "__REGISTER__":
+            if token in tokens:
+                tokens[token]["address"] = address
+                self.room_manager.save_to_json()
+                print(f"[登録] トークン {token[:8]}... にアドレス {address} を登録しました\n")
+            else:
+                print(f"[登録拒否] 未知のトークン {token[:8]}...")
+            return
+
+        if message == "__JOIN__":
+            if self.room_manager.validate_token_and_address(token, room_name)[0]:
+                confirmation = f"ルーム '{room_name}' に参加しました"
+                self.udp_sock.sendto(confirmation.encode('utf-8'), address)
+                print(f"[JOIN] {token[:8]}... がルーム {room_name} に参加しました")
+            else:
+                print(f"[JOIN失敗] バリデーションエラー: token={token[:8]}...")
+            return
+
+        is_valid, reason = self.room_manager.validate_token_and_address(token, room_name)
+        if not is_valid:
+            print(f"[バリデーション失敗] {reason}")
+            return
+
+        if room_name not in rooms or token not in tokens:
+            print("[中継失敗] ルームまたはトークンが存在しません")
+            return
+
+        sender = tokens[token]["username"]
+        members = rooms[room_name]["members"]
+
+        for member_token in members:
+            if member_token == token:
+                continue
+
+            addr = tokens[member_token].get("address")
+            if not addr:
+                continue
+
+            if isinstance(addr, list):
+                addr = tuple(addr)
+
+            try:
+                payload = build_udp_message(sender, message)
+                self.udp_sock.sendto(payload, addr)
+                print(f"[送信] {tokens[member_token]['username']} へ: {message}")
+            except Exception as e:
+                print(f"[送信エラー] {tokens[member_token]['username']}: {e}")
+
     def stop(self):
         self.running = False
         if self.udp_sock:
             self.udp_sock.close()
-            self.udp_sock = None
-            print("UDPサーバー停止")
+            print("[停止] UDPサーバーを停止しました")


### PR DESCRIPTION
## UDPベースチャットシステムの実装

TCPで認証した情報をもとに、UDPベースのチャットシステムを実装しました。

- ユーザーはCLI引数からチャットルームに参加し、UDPサーバを通じてリアルタイムにメッセージを中継できます。
- サーバ側では、**トークン認証**、**ルーム名の一致**、**IPアドレスの検証**などのバリデーションを実施しています。

### 主な変更点

- TCP認証後のユーザー情報を活用したUDPチャット通信の追加
- ルーム・トークン・IPの検証機能
- CLIによるチャット参加フロー

### 起動コマンド例

#### サーバー起動

```bash
cd server
python server.py
```

#### クライアント起動

```bash
cd client
python client.py
```
